### PR TITLE
[Editor] Fix multiple exceptions appear when using EnterPlayModeOptions.DisableDomainReload

### DIFF
--- a/Runtime/Core/Modules/CustomModules.cs
+++ b/Runtime/Core/Modules/CustomModules.cs
@@ -20,18 +20,21 @@ namespace ME.BECS {
 
         public static void RegisterResetPass(InitializeResetPass initializeResetPassCallback) {
 
+            resetPass -= initializeResetPassCallback;
             resetPass += initializeResetPassCallback;
 
         }
 
         public static void RegisterFirstPass(InitializeFirstPass initializeFirstPassCallback) {
 
+            firstPass -= initializeFirstPassCallback;
             firstPass += initializeFirstPassCallback;
 
         }
 
         public static void RegisterSecondPass(InitializeSecondPass initializeSecondPassCallback) {
 
+            secondPass -= initializeSecondPassCallback;
             secondPass += initializeSecondPassCallback;
 
         }

--- a/Runtime/ObjectReference/ObjectReference.StaticRegistry.cs
+++ b/Runtime/ObjectReference/ObjectReference.StaticRegistry.cs
@@ -15,6 +15,9 @@ namespace ME.BECS {
         }
 
         private static void EditorApplicationOnplayModeStateChanged(UnityEditor.PlayModeStateChange state) {
+             if (state != UnityEditor.PlayModeStateChange.EnteredEditMode) {
+                return;           
+            }
             if (UnityEditor.EditorSettings.enterPlayModeOptionsEnabled == true) {
                 data = null;
             }


### PR DESCRIPTION
The first fix is related to the fact that with DomainReload disabled, the CustomModules class accumulates subscriptions. Because of this, errors occur in NativeHashMap when we try to add the same key twice.

The second fix is related to the ObjectReferenceRegistry class, where EditorApplicationOnPlayModeStateChanged with the EnteredPlayMode state is called after the Load method. Since there are no state checks there, we end up entering the game with ObjectReferenceRegistry.data == null

I added a state check so that we only clear data when exiting Play Mode.