### PR TITLE
Fixed codegen Unity error

### DIFF
--- a/Editor/CodeGenerator/Generators/JobsEarlyInitCodeGenerator.cs
+++ b/Editor/CodeGenerator/Generators/JobsEarlyInitCodeGenerator.cs
@@ -313,7 +313,7 @@ namespace ME.BECS.Editor.Jobs {
                         foreach (var component in aspects) {
                             tempStructBuilder.AppendLine($"public {component} a{i};");
                             tempStructUnsafeBuilder.AppendLine($"[NativeDisableContainerSafetyRestriction] public {component} a{i};");
-                            tempFuncBuilder.AppendLine($"data->a{i} = buffer->state.ptr->aspectsStorage.Initialize<{component}>(buffer->state);");
+                            tempFuncBuilder.AppendLine($"data->a{i} = WorldAspectStorage.Initialize<{component}>(buffer->worldId);");
                             ++i;
                         }
                         


### PR DESCRIPTION
It caused errors when importing ME.BECS into a new project:
<img width="2088" height="368" alt="image" src="https://github.com/user-attachments/assets/a2ac7e4a-e939-4e71-bb5a-9813ed13bc24" />

I replaced `WorldAspectStorage.Initialize<T>(worldId)` instead of `state.ptr->aspectsStorage.Initialize<T>(state)` in `JobsEarlyInitCodeGenerator.cs`. Not sure if it's the right thing to do, but it fixed the error.