### PR TITLE
[Editor] reset world hierarchy window on playModeStateChanged

### DIFF
--- a/Addons/Features/Editor/WorldHierarchyEditorWindow.cs
+++ b/Addons/Features/Editor/WorldHierarchyEditorWindow.cs
@@ -1,8 +1,8 @@
 using System.Linq;
 using ME.BECS.Transforms;
-using UnityEngine;
 using UnityEditor;
 using UnityEditor.UIElements;
+using UnityEngine;
 using UnityEngine.UIElements;
 
 namespace ME.BECS.Editor {
@@ -155,6 +155,9 @@ namespace ME.BECS.Editor {
             SceneView.duringSceneGui -= OnSceneGUI;
             SceneView.duringSceneGui += OnSceneGUI;
             
+            EditorApplication.playModeStateChanged -= ClearWindowData;
+            EditorApplication.playModeStateChanged += ClearWindowData;
+            
             this.search = EditorPrefs.GetString("ME.BECS.WorldHierarchyEditorWindow.search", string.Empty);
 
             EditorUtility.DisplayProgressBar("Hierarchy", "Initialization", 0f);
@@ -176,6 +179,21 @@ namespace ME.BECS.Editor {
                 EditorUtility.ClearProgressBar();
             }
 
+        }
+        
+        private void ClearWindowData(PlayModeStateChange state) {
+            if (state is PlayModeStateChange.ExitingPlayMode) {
+                this.aliveWorlds.Clear();
+                this.selectedWorld = default;
+                foldout.Clear();
+                entToTags.Clear();
+                entsToElements.Clear();
+                entToVersions.Clear();
+                entToComponentsCount.Clear();
+                selected.Clear();
+                current.Clear();
+                CreateGUI();
+            }
         }
 
         internal void SaveSettings() {
@@ -371,6 +389,7 @@ namespace ME.BECS.Editor {
         
         private void CreateGUI() {
 
+            Selection.selectionChanged -= this.OnSelectionChanged;
             Selection.selectionChanged += this.OnSelectionChanged;
 
             this.LoadSettings();


### PR DESCRIPTION
If you use the Editor with the “Disable Domain Reload” option enabled, there’s a bug where the selected world in the World Hierarchy editor window is not cleared unless you reopen the window or switch to another world.
I added a fix so that the current world selection is cleared when exiting Play Mode.

The first video shows the bug being reproduced without the fix.
https://github.com/user-attachments/assets/6e0faf5d-a440-4002-90e5-a8fdd8124b7d

The second video shows the behavior with the fix applied.
https://github.com/user-attachments/assets/0c6430f4-d27c-467e-b94f-2e22bf65d698

