### PR TITLE
[Editor] Fix compilation error for unity 6000.3.0f1

### DIFF
--- a/Editor/Extensions/NodeGraphProcessor/Editor/Views/BaseGraphView.cs
+++ b/Editor/Extensions/NodeGraphProcessor/Editor/Views/BaseGraphView.cs
@@ -115,7 +115,6 @@ namespace ME.BECS.Extensions.GraphProcessor
 		/// <summary>
 		/// Object to handle nodes that shows their UI in the inspector.
 		/// </summary>
-		[SerializeField]
 		protected NodeInspectorObject		nodeInspector
 		{
 			get


### PR DESCRIPTION
There is a compilation error in unity 6000.3.0f1
As far as this property has only getter, there is no need for a serializefield attribute