### PR TITLE
Fixed GlobalEvents discarding latest data

### DIFF
--- a/Runtime/GlobalEvents/GlobalEvents.cs
+++ b/Runtime/GlobalEvents/GlobalEvents.cs
@@ -179,7 +179,7 @@ namespace ME.BECS {
                 var elem = item.events[evt];
                 if (elem.data.ptr != null) {
                     fixed (void* dataPtr = &data) {
-                        _memcpy(elem.data, (safe_ptr)dataPtr, TSize<T>.size);
+                        _memcpy((safe_ptr)dataPtr, elem.data, TSize<T>.size);
                     }
                 } else {
                     elem.data = useData == true ? _make(data) : default;


### PR DESCRIPTION
GlobalEvents is expected to use latest data.
Currently it unexpectedly discards latest data due to a misplaced arguments.
This PR fixes the issue.