### PR TITLE
[Editor] Tooltip exception fix

### DIFF
--- a/Editor/EntityConfig/EntityConfigEditor.cs
+++ b/Editor/EntityConfig/EntityConfigEditor.cs
@@ -570,7 +570,7 @@ namespace ME.BECS.Editor {
                     labelField.AddToClassList("unity-foldout");
                     elementContainer.Add(labelField);
                     rootElement = elementContainer;
-                    var foldoutLabel = labelField.Q<Toggle>();
+                    var foldoutLabel = labelField.Q<Toggle>() ?? (VisualElement)labelField;
                     EditorUIUtils.DrawTooltip(foldoutLabel, EditorUtils.GetComponent(type)?.GetEditorComment());
                     labelField.RegisterCallback<ClickEvent>((evt) => { updateButtons.Invoke(list, idx); });
                     labelField.text = label;


### PR DESCRIPTION
Fixed editor exceptions when drawing an EditorTooltip for a component without a foldout (usually tags), e.g. IsTransformStaticComponent