### PR TITLE
[Core] Removed unnecessary memclear for already cleared memory

### DIFF
--- a/Runtime/Utils/Cuts.cs
+++ b/Runtime/Utils/Cuts.cs
@@ -352,10 +352,12 @@ namespace ME.BECS {
 
                 var size = newLength * TSize<T>.size;
                 var ptr = (safe_ptr<T>)_make(size, TAlign<T>.alignInt, allocator);
-                _memclear(ptr, size);
                 if (arr.ptr != null) {
                     _memcpy(arr, ptr, length * TSize<T>.size);
+                    _memclear((safe_ptr)(ptr + length), (newLength - length) * TSize<T>.size);
                     if (free == true) _free(arr, allocator);
+                } else {
+                    _memclear(ptr, size);
                 }
 
                 arr = ptr;


### PR DESCRIPTION
Newly allocated memory is already FULLY cleared at line 355, so there is no need to to clear non-copied part again