### PR TITLE
[Collections] Fixed unnecessary capacity grow modifier

### DIFF
--- a/Runtime/MemoryAllocator/Collections/Auto/ListAuto.cs
+++ b/Runtime/MemoryAllocator/Collections/Auto/ListAuto.cs
@@ -246,7 +246,7 @@ namespace ME.BECS {
         public bool EnsureCapacity(uint capacity) {
 
             capacity = Helpers.NextPot(capacity);
-            return this.arr.Resize(capacity, 2, ClearOptions.UninitializedMemory);
+            return this.arr.Resize(capacity, 1, ClearOptions.UninitializedMemory);
             
         }
         


### PR DESCRIPTION
Fixed unnecessary capacity enlargement.

Capacity is evaluated as NEXT power of two, so there is no need to supply 2 as a growth factor.
This leads to unnecessarily large array allocations.
For example:
1) ListAuto has 32 elements
2) Another element is being added
3) Capacity is evaluated as 64 (NPOT)
4) Resize receives 64 as newLengh AND muliplies it by 2