### PR TITLE
Fixed objectLookup not being populated on config load

### DIFF
--- a/Runtime/EntityConfig/EntityConfig.StaticRegistry.cs
+++ b/Runtime/EntityConfig/EntityConfig.StaticRegistry.cs
@@ -108,7 +108,7 @@ namespace ME.BECS {
                     Logger.Core.Warning($"Config is null while loading #{obj.sourceId}");
                     return;
                 }
-                ObjectReferenceRegistry.data.objectLookup.Add(config, processItem.objectItem.sourceId);
+                ObjectReferenceRegistry.data.objectLookup.TryAdd(config, processItem.objectItem.sourceId);
                 var unsafeConfig = config.AsUnsafeConfig();
                 if (unsafeConfig.IsValid() == false) return;
                 TryAdd(obj.sourceId, unsafeConfig);

--- a/Runtime/EntityConfig/EntityConfig.StaticRegistry.cs
+++ b/Runtime/EntityConfig/EntityConfig.StaticRegistry.cs
@@ -108,6 +108,7 @@ namespace ME.BECS {
                     Logger.Core.Warning($"Config is null while loading #{obj.sourceId}");
                     return;
                 }
+                ObjectReferenceRegistry.data.objectLookup.Add(config, processItem.objectItem.sourceId);
                 var unsafeConfig = config.AsUnsafeConfig();
                 if (unsafeConfig.IsValid() == false) return;
                 TryAdd(obj.sourceId, unsafeConfig);


### PR DESCRIPTION
ObjectLookup should be populated on config load.
Otherwise UnsafeEntityConfig gets a runtime-generated sourceId (nextId + (++nextRuntimeId) inside the AddRuntimeObject method).
It leads to failed comparisons between Config.sourceId and UnsafeEntityConfig.id pointing to the same configs. It's possible to workaround this by turning Config into an UnsafeEntityConfig beforehand, but still kinda unexpected.